### PR TITLE
Create recipes to test more features of the vsphere driver

### DIFF
--- a/cookbooks/provision/recipes/centos_provision_with_customization_spec.rb
+++ b/cookbooks/provision/recipes/centos_provision_with_customization_spec.rb
@@ -1,0 +1,46 @@
+require 'chef/provisioning'
+require 'chef/provisioning/vsphere_driver'
+
+#
+# This is the main way to connect to vSphere
+#
+with_vsphere_driver host: '172.16.20.2',
+  insecure: true,
+  user:     'administrator@vsphere.local',
+  password: 'Good4bye!'
+
+#
+# These are the machine_options that you need to declare
+#
+with_machine_options :bootstrap_options => {
+                               num_cpus: 2,
+                               memory_mb: 4096,
+                               datacenter: 'Datacenter',
+                               resource_pool: 'Cluster',
+                               template_name: 'centos7-tmpl',
+                               :ssh => {
+                                 :user => 'root',
+                                 :password => 'admini',
+                                 :paranoid => false,
+                               },
+                               bootstrap_ipv4: true,
+
+                               # These ip settings need to be updated based on the vCenter setup
+                               customization_spec: {
+                                 ipsettings: {
+                                   ip: '192.168.3.4',
+                                   subnetMask: '255.255.255.0',
+                                   gateway: ['192.168.3.1'],
+                                   dnsServerList: ['1.2.3.31', '1.2.3.41'],
+                                 },
+                                 domain: 'local',
+                               },
+                             }
+
+#
+# This is where you can declare the machine
+#
+machine "testing-centos-with-customization-spec" do
+  tag "haha"
+  tag "customization-spec"
+end

--- a/cookbooks/provision/recipes/centos_provision_with_disks.rb
+++ b/cookbooks/provision/recipes/centos_provision_with_disks.rb
@@ -1,0 +1,37 @@
+require 'chef/provisioning'
+require 'chef/provisioning/vsphere_driver'
+
+#
+# This is the main way to connect to vSphere
+#
+with_vsphere_driver host: '172.16.20.2',
+  insecure: true,
+  user:     'administrator@vsphere.local',
+  password: 'Good4bye!'
+
+#
+# These are the machine_options that you need to declare
+#
+with_machine_options :bootstrap_options => {
+                               num_cpus: 2,
+                               memory_mb: 4096,
+                               datacenter: 'Datacenter',
+                               resource_pool: 'Cluster',
+                               template_name: 'centos7-tmpl',
+                               :ssh => {
+                                 :user => 'root',
+                                 :password => 'admini',
+                                 :paranoid => false,
+                               },
+                               bootstrap_ipv4: true,
+
+                               additional_disk_size_gb: [10, 20],
+                             }
+
+#
+# This is where you can declare the machine
+#
+machine "testing-centos-with-additional-disks" do
+  tag "haha"
+  tag "additional-disks"
+end

--- a/cookbooks/provision/recipes/centos_provision_with_iso.rb
+++ b/cookbooks/provision/recipes/centos_provision_with_iso.rb
@@ -1,0 +1,38 @@
+require 'chef/provisioning'
+require 'chef/provisioning/vsphere_driver'
+
+#
+# This is the main way to connect to vSphere
+#
+with_vsphere_driver host: '172.16.20.2',
+  insecure: true,
+  user:     'administrator@vsphere.local',
+  password: 'Good4bye!'
+
+#
+# These are the machine_options that you need to declare
+#
+with_machine_options :bootstrap_options => {
+                               num_cpus: 2,
+                               memory_mb: 4096,
+                               datacenter: 'Datacenter',
+                               resource_pool: 'Cluster',
+                               template_name: 'centos7-tmpl',
+                               :ssh => {
+                                 :user => 'root',
+                                 :password => 'admini',
+                                 :paranoid => false,
+                               },
+                               bootstrap_ipv4: true,
+
+                               # An iso needs to be uploaded to a datastore, and updated here
+                               initial_iso_file: '[SomeDataStoreName] centos.iso'
+                             }
+
+#
+# This is where you can declare the machine
+#
+machine "testing-centos-with-iso" do
+  tag "haha"
+  tag "iso"
+end

--- a/cookbooks/provision/recipes/centos_provision_with_named_customization_spec.rb
+++ b/cookbooks/provision/recipes/centos_provision_with_named_customization_spec.rb
@@ -1,0 +1,38 @@
+require 'chef/provisioning'
+require 'chef/provisioning/vsphere_driver'
+
+#
+# This is the main way to connect to vSphere
+#
+with_vsphere_driver host: '172.16.20.2',
+  insecure: true,
+  user:     'administrator@vsphere.local',
+  password: 'Good4bye!'
+
+#
+# These are the machine_options that you need to declare
+#
+with_machine_options :bootstrap_options => {
+                               num_cpus: 2,
+                               memory_mb: 4096,
+                               datacenter: 'Datacenter',
+                               resource_pool: 'Cluster',
+                               template_name: 'centos7-tmpl',
+                               :ssh => {
+                                 :user => 'root',
+                                 :password => 'admini',
+                                 :paranoid => false,
+                               },
+                               bootstrap_ipv4: true,
+
+                               # A customization spec needs to be creaed in vCenter and put in here
+                               customization_spec: 'some named customization spec'
+                             }
+
+#
+# This is where you can declare the machine
+#
+machine "testing-centos-with-named-customization-spec" do
+  tag "haha"
+  tag "named-customization-spec"
+end


### PR DESCRIPTION
I've created some more test cases for the vsphere driver.

However, we'll need to 
- Create a customization spec in vCenter & update the recipe
- Upload an ISO (perhaps the centos iso) & update the recipe
- Update `centos_provision_with_customization_spec` with proper IP address values
